### PR TITLE
Fix crash when command has no arguments

### DIFF
--- a/src/handlers/stateless_handler.rs
+++ b/src/handlers/stateless_handler.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::cmp::min;
 use handlers::{Message, MessageHandler, extract_command, HandleResult};
 use MatrixBot;
 
@@ -52,7 +53,7 @@ impl MessageHandler for StatelessHandler {
                                             println!("Found handle for command \"{}\". Calling it.", &command);
                                         }
                                         let end_of_prefix = self.cmd_prefix.len() + command.len();
-                                        func(bot, message, &message.body[end_of_prefix+1..])
+                                        func(bot, message, &message.body[min(end_of_prefix+1, message.body.len())..])
                                     }
                                     None => {
                                         if bot.verbose {


### PR DESCRIPTION
When issued with only a command and no arguments (`!mycmd`) it will crash with an out of bounds error.

By the way, most changes in your repository have been stolen upstream: https://github.com/zwieberl/matrix_bot_api/commit/af662e4025fdb55f815ce8555d57e2268c18829f